### PR TITLE
Add iFood scraping example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Hi Humans!
 
 Gutemberg here, I like Java and JSC and Primeface and that's what I'm made of.
 
-I'm a beginner and I'm so excited to learn how to code. I'm ooking forward to 
-
+I'm a beginner and I'm so excited to learn how to code. I'm ooking forward to
 helping and colaborating in many projects around the world.
 
 
@@ -15,3 +14,20 @@ Best,
 
 
 Gutemberg
+
+## Scraping iFood
+
+This repository now includes a sample script `scrape_ifood.py` that demonstrates
+how to fetch the iFood homepage using `requests` and `BeautifulSoup`.
+
+### Usage
+
+1. Install the dependencies:
+   ```bash
+   pip install requests beautifulsoup4
+   ```
+2. Run the script:
+   ```bash
+   python3 scrape_ifood.py
+   ```
+   The script prints the page title of the iFood homepage.

--- a/scrape_ifood.py
+++ b/scrape_ifood.py
@@ -1,0 +1,28 @@
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_homepage():
+    url = "https://www.ifood.com.br"
+    headers = {
+        "User-Agent": "Mozilla/5.0"
+    }
+    response = requests.get(url, headers=headers)
+    response.raise_for_status()
+    return response.text
+
+
+def parse_homepage(html):
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.title.text.strip() if soup.title else "No title found"
+    return {"title": title}
+
+
+def main():
+    html = fetch_homepage()
+    data = parse_homepage(html)
+    print("Page title:", data["title"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple example script `scrape_ifood.py` for scraping the iFood homepage
- document how to use the script in the README

## Testing
- `python3 -m pip show requests 2>&1 | head -n 2 || true`
- `python3 scrape_ifood.py 2>&1 | head -n 20 || true`


------
https://chatgpt.com/codex/tasks/task_e_68558f6eff048327bf6d3d4d0eb51296